### PR TITLE
Feature/chat extract link

### DIFF
--- a/app/routes/chats.tsx
+++ b/app/routes/chats.tsx
@@ -55,6 +55,10 @@ export default function Chats() {
           <Text pt="5">
             2. Do not click on any suspicious links or download any attachments.
           </Text>
+            <Text fontSize="sm">
+              Any links in the chat will be sent to inspection. Clicking on the
+              link will redirect you to the inspection page
+            </Text>
           <Text pt="5">
             3. Stay vigilant and keep an eye out for common scammer tactics like
             urgency, fear-mongering, and unsolicited offers.

--- a/app/routes/chats.tsx
+++ b/app/routes/chats.tsx
@@ -37,16 +37,15 @@ export default function Chats() {
         overflowY="hidden"
         h="calc(100vh - 60px)"
         position="relative"
-        templateRows="repeat(1, 1fr)"
         templateColumns="repeat(10, 1fr)"
         gap={0}
       >
         <GridItem
-          rowSpan={1}
           colSpan={3}
-          p="10"
+          p="8"
           borderRight="1px"
           borderColor="gray.200"
+          overflowY="scroll"
         >
           <Heading size="lg">Chat with Scammers!</Heading>
           <Image src={image} pb="5" />
@@ -56,7 +55,7 @@ export default function Chats() {
             2. Do not click on any suspicious links or download any attachments.
           </Text>
             <Text fontSize="sm">
-              Any links in the chat will be sent to inspection. Clicking on the
+              Links in the chat will be sent to inspection. Clicking on the
               link will redirect you to the inspection page
             </Text>
           <Text pt="5">
@@ -66,7 +65,6 @@ export default function Chats() {
         </GridItem>
 
         <GridItem
-          rowSpan={1}
           colSpan={2}
           borderRight="1px"
           borderColor="gray.200"
@@ -78,8 +76,8 @@ export default function Chats() {
                 <Box
                   h="80px"
                   borderBottom="1px"
-                  bg={isActive ? "blue.100" : ""}
-                  _hover={isActive ? {} : { bg: "blue.50" }}
+                  bg={isActive ? "gray.100" : ""}
+                  _hover={isActive ? {} : { bg: "gray.50" }}
                   borderBottomColor="gray.200"
                   p="4"
                 >
@@ -115,7 +113,7 @@ export default function Chats() {
             </NavLink>
           ))}
         </GridItem>
-        <GridItem rowSpan={1} colSpan={5}>
+        <GridItem colSpan={5}>
           {/* Individual Chat area */}
           <Outlet />
         </GridItem>

--- a/app/routes/chats/$chatId.tsx
+++ b/app/routes/chats/$chatId.tsx
@@ -45,10 +45,15 @@ export const loader = async ({ params }: LoaderArgs) => {
             .replace(/>/g, "&gt;");
 
           message.text = message.text.replace(urlRegex, (url) => {
-            inspectLink(url)
+            try {
+              inspectLink(url);
+            } catch (error) {
+              console.error(error);
+            }
             const encodedUrl = encodeURIComponent(url);
             const inspectUrl = "/inspect/" + encodedUrl;
             return `<a 
+            title="Click to Inspect"
             href="${inspectUrl}" 
             target="_blank"
             style="color:#458DC8; text-decoration:underline"  


### PR DESCRIPTION
extract links
https://user-images.githubusercontent.com/31789023/230769692-9b7f1a80-c299-46a2-90d4-f6a1c31af7fe.mov

currently, all the messages with a link will be inspected again when it is retrieved. 
problems:
1. link is inspected multiple times, don't think it's efficient
2. link is only inspected when it is retrieved by users, could be inspected when the message was first stored in the db so that it could be taken down asap?

might not fix cos its week 14 woot woot
